### PR TITLE
Make "address" an optional field

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This variable allows configuring the WireGuard interface on the host. It is a di
 
 | Key | Description | Required |
 | --- | ----------- | -------- |
-| address | The address to be configured on the interface in CIDR format | Yes |
 | private_key | The private key to use for this interface | Yes |
+| address | The address to be configured on the interface in CIDR format | No |
 | listen_port | A port to listen to, a random port is used if unset | No |
 
 Other configurable things:

--- a/templates/wgX.conf.j2
+++ b/templates/wgX.conf.j2
@@ -1,8 +1,9 @@
 {% set interface = lookup('vars', 'wireguard_' + item + '_interface') -%}
 {% set peers = lookup('vars', 'wireguard_' + item + '_peers') -%}
 
-{% set interface_required_keys = { 'address': 'Address', 'private_key': 'PrivateKey' } -%}
+{% set interface_required_keys = { 'private_key': 'PrivateKey' } -%}
 {% set interface_optional_keys = {
+   'address': 'Address',
    'listen_port': 'ListenPort',
    'fw_mark': 'FwMark',
    'dns': 'DNS',


### PR DESCRIPTION
WireGuard interfaces themselves do not need to have addresses attached.  When using WireGuard as virtual links to connect subnets, we do not need to assign addresses to the wireguard interfaces.