### PR TITLE
Use the builtin Ubuntu capability for adding universe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - distro: fedora27
   - distro: ubuntu1604
   - distro: ubuntu1804
+  - distro: ubuntu2004
 
 script:
   # Download test shim.

--- a/tasks/ubuntu_repositories.yml
+++ b/tasks/ubuntu_repositories.yml
@@ -6,3 +6,8 @@
   register: adduniverserepo
   changed_when: "'already enabled' not in adduniverserepo.stdout"
   when: ansible_distribution == 'Ubuntu'
+
+- name: Update APT repositories # only if they're old!
+  apt:
+    update_cache: yes
+    cache_valid_time: 604800 # one week

--- a/tasks/ubuntu_repositories.yml
+++ b/tasks/ubuntu_repositories.yml
@@ -1,6 +1,5 @@
 ---
 - name: Add Ubuntu repositories
-  become: true
   # Use the builtin Ubuntu capability for adding universe, within which wireguard lives
   command: "add-apt-repository universe"
   register: adduniverserepo

--- a/tasks/ubuntu_repositories.yml
+++ b/tasks/ubuntu_repositories.yml
@@ -7,6 +7,11 @@
   changed_when: "'already enabled' not in adduniverserepo.stdout"
   when: ansible_distribution == 'Ubuntu'
 
+- name: Remove old PPA
+  apt_repository:
+    repo: 'ppa:wireguard/wireguard'
+    state: absent
+
 - name: Update APT repositories # only if they're old!
   apt:
     update_cache: yes

--- a/tasks/ubuntu_repositories.yml
+++ b/tasks/ubuntu_repositories.yml
@@ -1,6 +1,8 @@
 ---
 - name: Add Ubuntu repositories
-  apt_repository:
-    repo: 'ppa:wireguard/wireguard'
-    state: present
+  become: true
+  # Use the builtin Ubuntu capability for adding universe, within which wireguard lives
+  command: "add-apt-repository universe"
+  register: adduniverserepo
+  changed_when: "'already enabled' not in adduniverserepo.stdout"
   when: ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
Fixes #10. Ubuntu keeps its wireguard repo within "universe", which not all systems will have enabled.  This update enables "universe", so this is used instead of the PPA.